### PR TITLE
Switch to only publish on tag

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -2,8 +2,9 @@
 name: Publish to PyPI
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
 jobs:
   build-n-publish:
     name: Build and publish refac


### PR DESCRIPTION
With this our general workflow out be...

1. Establish we want to release
2. Push tag
3. This triggers and publishes to PyPI
4. Manually create the release using the tag (we might be able to automate that as well -- but for now easy enough to just do it as we likely won't have tons of these