### PR TITLE
bug: Fix regex filtering for Python files

### DIFF
--- a/src/refac/move_file.py
+++ b/src/refac/move_file.py
@@ -37,7 +37,7 @@ def codemod_imports(
     old_module = to_module(old_path)
     new_module = to_module(new_path)
 
-    grep_for_filenames_command = f"git grep --files-with-matches --extended-regexp '{old_module.rsplit('.', 1)[1]}' {str(ROOT_DIR)} | grep -E '\.py$'"
+    grep_for_filenames_command = f"git grep --files-with-matches --extended-regexp '{old_module.rsplit('.', 1)[1]}' {str(ROOT_DIR)} | grep -E '[.]py$'"
     codemod_command = f"python3 -m libcst.tool codemod __init__.ReplaceImportCodemod --old={old_module} --new={new_module}"
     command = f"{grep_for_filenames_command} | xargs {codemod_command}"
     shell(command)

--- a/src/refac/move_import.py
+++ b/src/refac/move_import.py
@@ -61,7 +61,7 @@ def codemod_imports(srcs: List[str], dsts: List[str]) -> None:
     symbols = [old_symbol.rsplit(".", 1)[1] for old_symbol in srcs]
     combined = "(" + "|".join(symbols) + ")"
 
-    grep_for_filenames_command = f"git grep --files-with-matches --extended-regexp '{combined}' {str(ROOT_DIR)} | grep -E '\.py$'"
+    grep_for_filenames_command = f"git grep --files-with-matches --extended-regexp '{combined}' {str(ROOT_DIR)} | grep -E '[.]py$'"
     codemod_command = f"python3 -m libcst.tool codemod __init__.ReplaceImportCodemod --old={','.join(srcs)} --new={','.join(dsts)}"
     command = f"{grep_for_filenames_command} | xargs {codemod_command}"
     shell(command)

--- a/src/refac/move_symbol.py
+++ b/src/refac/move_symbol.py
@@ -102,7 +102,7 @@ def codemod_imports(old_symbols: List[str], new_symbols: List[str]) -> None:
     symbols = [old_symbol.rsplit(".", 1)[1] for old_symbol in old_symbols]
     combined = "(" + "|".join(symbols) + ")"
 
-    grep_for_filenames_command = f"git grep --files-with-matches --extended-regexp '{combined}' {str(ROOT_DIR)} | grep -E '\.py$'"
+    grep_for_filenames_command = f"git grep --files-with-matches --extended-regexp '{combined}' {str(ROOT_DIR)} | grep -E '[.]py$'"
     codemod_command = f"python3 -m libcst.tool codemod __init__.ReplaceImportCodemod --old={','.join(old_symbols)} --new={','.join(new_symbols)}"
     command = f"{grep_for_filenames_command} | xargs {codemod_command}"
     shell(command)


### PR DESCRIPTION
Previously, the `\` was getting escaped and was being written as `\\.py` which filter out all files.

This updated regex matches the `.py` suffix a bit more robustly.

<img width="326" alt="image" src="https://user-images.githubusercontent.com/1903527/228309591-dc6d5dac-bf5f-4b04-af3c-26642ff3b969.png">
