### PR TITLE
bug: Check for relative import before looking up context.filename

### DIFF
--- a/src/refac/visitors/import_utils.py
+++ b/src/refac/visitors/import_utils.py
@@ -182,7 +182,7 @@ def get_absolute_module_for_import(
     context: CodemodContext, node: cst.ImportFrom
 ) -> str:
     full_module_name = context.full_module_name
-    if context.filename.endswith("__init__.py") and node.relative:  # type: ignore[union-attr]
+    if node.relative and context.filename.endswith("__init__.py"):  # type: ignore[union-attr]
         # The module `a.b` can refer to either `a/b.py` or `a/b/__init__.py`.
         # To correctly disambiguate relative imports from __init__ files, we
         # append an `.__init__` module.


### PR DESCRIPTION
If a `--format` argument is passed to `ReplaceImport`, we try and represent it as an `Import` object.

At this point, we won't have a `context.filename` and will raise an error when trying to normalize a relative import. We don't need to worry about relative imports for imports being passed as `--format`.

This PR moves the relative import check up first so it'll early exit and skip the `context.filename` lookup.